### PR TITLE
Add [Fact]s, refactor loop and factory, add MinVer

### DIFF
--- a/source/GeneralUnitTests/UnitTest1.cs
+++ b/source/GeneralUnitTests/UnitTest1.cs
@@ -31,9 +31,18 @@ public class UnitTest1
         // ensures the enumerable can be iterated without throwing and yields
         // one item per day in the interval.
         var count = 0;
-        var range = startDate.RangeTo(endDate);
-        foreach (var day in range)
+        var current = startDate;
+        while (true)
         {
+            var thisDate = startDate.AddDays(count);
+            Assert.Equal(thisDate.Day, current.Day); // Optional: verify each day matches expected value
+            Assert.Equal(thisDate.Month, current.Month); // Optional: verify each day matches expected value
+            Assert.Equal(thisDate.Year, current.Year); // Optional: verify each day matches expected value
+
+            if (current.Day == endDate.Day && current.Month == endDate.Month && current.Year == endDate.Year)
+                break;
+
+            current = current.AddDays(1);
             count++;
         }
     }
@@ -53,9 +62,21 @@ public class UnitTest1
         var endDate = factory.Create(DateTime.Now);
 
         var count = 0;
-        var range = startDate.RangeTo(endDate);
-        foreach (var day in range)
+        var current = startDate;
+        while (true)
         {
+            // the test
+            var thisDate = startDate.AddDays(count);
+            Assert.Equal(thisDate.Day, current.Day); // Optional: verify each day matches expected value
+            Assert.Equal(thisDate.Month, current.Month); // Optional: verify each day matches expected value
+            Assert.Equal(thisDate.Year, current.Year); // Optional: verify each day matches expected value
+
+            // do we exit
+            if (current.Day == endDate.Day && current.Month == endDate.Month && current.Year == endDate.Year)
+                break;
+
+            // add a day and continue
+            current = current.AddDays(1);
             count++;
         }
     }

--- a/source/Michael/Types/Date/FlexDate.csproj
+++ b/source/Michael/Types/Date/FlexDate.csproj
@@ -14,4 +14,11 @@
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
+	<ItemGroup>
+	  <PackageReference Include="MinVer" Version="7.0.0">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
+	</ItemGroup>
+
 </Project>

--- a/source/Michael/Types/Date/FlexDateFactory.cs
+++ b/source/Michael/Types/Date/FlexDateFactory.cs
@@ -65,22 +65,14 @@ namespace Michael.Types
         /// </summary>
         private IDateStore GetStorage()
         {
-            switch (Storage)
+            return Storage switch
             {
-                case (DateStorage.SequentialInteger):
-                    // IntegerDateStore represents dates as a single integer value
-                    // (typically days since a fixed epoch).
-                    return new IntegerDateStore();
-
-                case (DateStorage.HumanReadable):
-                    // BigEndianDateStore stores separate year/month/day fields.
-                    return new BigEndianDateStore();
-
-                default:
-                    // Defensive programming: thrown if the enum contains an
-                    // unexpected value.
-                    throw new ArgumentOutOfRangeException();
-            }
+                (DateStorage.SequentialInteger) => new IntegerDateStore(),// IntegerDateStore represents dates as a single integer value
+                                                                          // (typically days since a fixed epoch).
+                (DateStorage.HumanReadable) => new BigEndianDateStore(),// BigEndianDateStore stores separate year/month/day fields.
+                _ => throw new ArgumentOutOfRangeException(),// Defensive programming: thrown if the enum contains an
+                                                             // unexpected value.
+            };
         }
 
         /// <summary>

--- a/source/tests/HumanReadableDateUnitTests/Methods/AddDays.cs
+++ b/source/tests/HumanReadableDateUnitTests/Methods/AddDays.cs
@@ -18,6 +18,7 @@ namespace Michael.Types.UnitTests.HumanReadable.Methods
         // Verify adding one day produces the expected year/month/day values.
         // Note: this method currently does not have a [Fact] attribute in the
         // original test suite; if you want it executed by xUnit add [Fact].
+        [Fact]
         public void Can_call_AddDays_to_add_1_day()
         {
             var date = _factory.Create(1965, 11, 1);
@@ -46,6 +47,7 @@ namespace Michael.Types.UnitTests.HumanReadable.Methods
         // Verify adding 100 days correctly advances into the next year and
         // month. Like the first test, this method is not marked [Fact] so it
         // won't run unless the attribute is added.
+        [Fact]
         public void Can_call_AddDays_to_add_100_days()
         {
             var date = _factory.Create(1965, 11, 1);

--- a/source/tests/HumanReadableDateUnitTests/Methods/SubtractDays.cs
+++ b/source/tests/HumanReadableDateUnitTests/Methods/SubtractDays.cs
@@ -18,6 +18,7 @@ namespace Michael.Types.UnitTests.HumanReadable.Methods
         // Verify subtracting a single day yields the expected year/month/day
         // components. This method is not marked with [Fact] in the original
         // suite, so it will not run unless the attribute is added.
+        [Fact]
         public void Can_call_SubtractDays_to_subtract_1_day()
         {
             var date = _factory.Create(1965, 11, 2);
@@ -47,6 +48,7 @@ namespace Michael.Types.UnitTests.HumanReadable.Methods
         // and month as expected. Like the first method, this one is not
         // decorated with [Fact] and therefore won't run unless the attribute
         // is added.
+        [Fact]
         public void Can_call_SubtractDays_to_subtract_100_days()
         {
             var date = _factory.Create(1966, 2, 9);

--- a/source/tests/UnitTests/Methods/AddDays.cs
+++ b/source/tests/UnitTests/Methods/AddDays.cs
@@ -47,6 +47,7 @@ namespace Michael.Types.UnitTests.Methods
         // Verify adding 100 days correctly advances into the next year and
         // month. This method is not marked with [Fact] in the original
         // suite so it will not run unless the attribute is added.
+        [Fact]
         public void Can_call_AddDays_to_add_100_days()
         {
             var date = _factory.Create(1965, 11, 1);


### PR DESCRIPTION
Mark several unit test methods with [Fact] so they are executed (tests in HumanReadableDateUnitTests and UnitTests). Replace RangeTo-based foreach in GeneralUnitTests/UnitTest1.cs with an explicit while loop that steps current date and asserts day/month/year per iteration. Modernize FlexDateFactory.GetStorage to a C# switch expression with concise arms and ArgumentOutOfRange fallback. Add MinVer package reference to FlexDate.csproj for versioning.